### PR TITLE
ism330dhcx driver: Fixed most mcuastyle errors

### DIFF
--- a/ism330dhcx_reg.c
+++ b/ism330dhcx_reg.c
@@ -1341,7 +1341,7 @@ int32_t ism330dhcx_temp_flag_data_ready_get(stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  * @brief  Accelerometer X-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[set]
   *
@@ -1360,7 +1360,7 @@ int32_t ism330dhcx_xl_usr_offset_x_set(stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  * @brief  Accelerometer X-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[get]
   *
@@ -1379,7 +1379,7 @@ int32_t ism330dhcx_xl_usr_offset_x_get(stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  * @brief  Accelerometer Y-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[set]
   *
@@ -1398,7 +1398,7 @@ int32_t ism330dhcx_xl_usr_offset_y_set(stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Accelerometer Y-axis user offset correction expressed in two’s
+  * @brief  Accelerometer Y-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[get]
   *
@@ -1417,7 +1417,7 @@ int32_t ism330dhcx_xl_usr_offset_y_get(stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Accelerometer Z-axis user offset correction expressed in two’s
+  * @brief  Accelerometer Z-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[set]
   *
@@ -1436,7 +1436,7 @@ int32_t ism330dhcx_xl_usr_offset_z_set(stmdev_ctx_t *ctx,
 }
 
 /**
-  * @brief  Accelerometer X-axis user offset correction expressed in two’s
+  * @brief  Accelerometer X-axis user offset correction expressed in two's
   *         complement, weight depends on USR_OFF_W in CTRL6_C (15h).
   *         The value must be in the range [-127 127].[get]
   *
@@ -1571,7 +1571,7 @@ int32_t ism330dhcx_timestamp_get(stmdev_ctx_t *ctx, uint8_t *val)
 /**
   * @brief  Timestamp first data output register (r).
   *         The value is expressed as a 32-bit word and the bit resolution
-  *         is 25 μs.[get]
+  *         is 25 us.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  buff   Buffer that stores data read
@@ -1673,7 +1673,7 @@ int32_t ism330dhcx_rounding_mode_get(stmdev_ctx_t *ctx,
 
 /**
   * @brief  Temperature data output register (r).
-  *         L and H registers together express a 16-bit word in two’s
+  *         L and H registers together express a 16-bit word in two's
   *         complement.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
@@ -1695,7 +1695,7 @@ int32_t ism330dhcx_temperature_raw_get(stmdev_ctx_t *ctx,
 
 /**
   * @brief  Angular rate sensor. The value is expressed as a 16-bit
-  *         word in two’s complement.[get]
+  *         word in two's complement.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  buff   Buffer that stores data read
@@ -1720,7 +1720,7 @@ int32_t ism330dhcx_angular_rate_raw_get(stmdev_ctx_t *ctx,
 
 /**
   * @brief  Linear acceleration output register. The value is expressed as a
-  *         16-bit word in two’s complement.[get]
+  *         16-bit word in two's complement.[get]
   *
   * @param  ctx    Read / write interface definitions.(ptr)
   * @param  buff   Buffer that stores data read
@@ -2112,7 +2112,8 @@ int32_t ism330dhcx_ln_pg_write(stmdev_ctx_t *ctx, uint16_t add,
   ism330dhcx_page_rw_t page_rw;
   ism330dhcx_page_sel_t page_sel;
   ism330dhcx_page_address_t page_address;
-  uint8_t msb, lsb;
+  uint8_t msb;
+  uint8_t lsb;
   int32_t ret;
   uint8_t i ;
   msb = (uint8_t)((add / 256U) & 0x0FU);

--- a/ism330dhcx_reg.h
+++ b/ism330dhcx_reg.h
@@ -2836,12 +2836,12 @@ typedef union
  * The __weak directive allows the final application to overwrite
  * them with a custom implementation.
  */
-int32_t __weak ism330dhcx_read_reg(stmdev_ctx_t *ctx, uint8_t reg,
-                                   uint8_t *data,
-                                   uint16_t len);
-int32_t __weak ism330dhcx_write_reg(stmdev_ctx_t *ctx, uint8_t reg,
-                                    uint8_t *data,
-                                    uint16_t len);
+int32_t ism330dhcx_read_reg(stmdev_ctx_t *ctx, uint8_t reg,
+                            uint8_t *data,
+                            uint16_t len);
+int32_t ism330dhcx_write_reg(stmdev_ctx_t *ctx, uint8_t reg,
+                             uint8_t *data,
+                             uint16_t len);
 
 float_t ism330dhcx_from_fs2g_to_mg(int16_t lsb);
 float_t ism330dhcx_from_fs4g_to_mg(int16_t lsb);

--- a/ism330dhcx_reg.h
+++ b/ism330dhcx_reg.h
@@ -50,7 +50,7 @@ extern "C" {
 /** if _BYTE_ORDER is not defined, choose the endianness of your architecture
   * by uncommenting the define which fits your platform endianness
   */
-//#define DRV_BYTE_ORDER    DRV_BIG_ENDIAN
+/* #define DRV_BYTE_ORDER    DRV_BIG_ENDIAN */
 #define DRV_BYTE_ORDER    DRV_LITTLE_ENDIAN
 
 #else /* defined __BYTE_ORDER__ */
@@ -2862,7 +2862,7 @@ float_t ism330dhcx_from_lsb_to_nsec(int32_t lsb);
 typedef enum
 {
   ISM330DHCX_2g   = 0,
-  ISM330DHCX_16g  = 1, /* if XL_FS_MODE = ‘1’ -> ISM330DHCX_2g */
+  ISM330DHCX_16g  = 1, /* if XL_FS_MODE = '1' -> ISM330DHCX_2g */
   ISM330DHCX_4g   = 2,
   ISM330DHCX_8g   = 3,
 } ism330dhcx_fs_xl_t;


### PR DESCRIPTION
Fixed most mcuastyle errors in the source and header files.

Signed-off-by: Carlo Parata <carlo.parata@st.com>